### PR TITLE
Fix: Stringables & Syntax

### DIFF
--- a/Addons/MRHHaloGear/cfghpp/cfgvehicles.hpp
+++ b/Addons/MRHHaloGear/cfghpp/cfgvehicles.hpp
@@ -67,7 +67,7 @@ class Man;
 					class MRH_DetachAAD { \
 						displayName = $STR_MRH_MRHHaloGear_REMOVEHAAD; \
 						condition = "_target getVariable ['MRH_HaloGear_itemAsAAD',false]"; \
-						statement = "[_target] call MRH_fnc_MilsimTools_HaloGear_removeObjectAAD;_player addItem 'MRH_AAD_Item';hint localize 'STR_MRH_MRHHaloGear_HintAADRemoved'" \
+						statement = "[_target] call MRH_fnc_MilsimTools_HaloGear_removeObjectAAD;_player addItem 'MRH_AAD_Item';hint localize 'STR_MRH_MRHHaloGear_HintAADRemoved'"; \
 						exceptions[] = {"isNotSwimming"}; \
 						showDisabled = 0; \
 						icon = ""; \

--- a/Addons/MRHSoldierTab/dialogs/videoChoiceMenu.hpp
+++ b/Addons/MRHSoldierTab/dialogs/videoChoiceMenu.hpp
@@ -55,7 +55,7 @@ class MRH_playVidButton: RscButtonMRHVideoChoice
 {
 	idc = 1601;
 	moving = true;
-	text = $STR_MRH_ST_playVid; //--- ToDo: Localize;
+	text = $STR_MRH_ST_playVid; // --- ToDo: Localize; //
 	action = "private _list = (findDisplay 241019)displayCtrl 2100;private _video = _list lbData (lbCurSel _list);private _screens = (findDisplay 241019) getVariable ['MRH_Brief_screens',[]];[_video,_screens] call MRH_fnc_MilsimTools_SoldierTab_playVideoOnScreens;closeDialog 0;"
 	x = 0.396875 * safezoneW + safezoneX;
 	y = 0.489 * safezoneH + safezoneY;

--- a/Addons/MRHSoldierTab/stringtable.xml
+++ b/Addons/MRHSoldierTab/stringtable.xml
@@ -237,11 +237,11 @@
 				<English>Briefing controls</English>
 				<French>Controles de briefing</French>
 			</Key>
-			<Key ID="STR_MRH_ST_">
+			/*<Key ID="STR_MRH_ST_">
 				<Original></Original>
 				<English></English>
 				<French></French>
-			</Key>
+			</Key>*/
 			
 			
 			

--- a/Addons/MRHTabletData/stringtable.xml
+++ b/Addons/MRHTabletData/stringtable.xml
@@ -14,7 +14,7 @@
 				<French>Fusil M4</French>
 			</Key>
 			
-			<Key ID="STR_MRH_MRHTabletData_">
+			/*<Key ID="STR_MRH_MRHTabletData_">
 				<Original></Original>
 				<English></English>
 				<French></French>
@@ -30,7 +30,7 @@
 				<Original></Original>
 				<English></English>
 				<French></French>
-			</Key>
+			</Key>/*
 			
 			
 		</Container>


### PR DESCRIPTION
Code was in stringable.xml twice causing RPT to spit out errors.

Syntax had a few errors. EG `Addons/MRHSoldierTab/dialogs/videoChoiceMenu.hpp` 

`Addons/MRHHaloGear/cfghpp/cfgvehicles.hpp` is still not perfect but is better then what it was.


https://pastebin.com/kZEAYmkF
{only has relevant info)
